### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/neural_structured_learning/keras/adversarial_regularization.py
+++ b/neural_structured_learning/keras/adversarial_regularization.py
@@ -87,7 +87,7 @@ def adversarial_loss(features,
     optimizer.apply_gradients(zip(gradients, model.trainable_variables))
   ```
 
-  Arguments:
+  Args:
     features: Input features, should be a `Tensor` or a collection of `Tensor`
       objects. If it is a collection, the first dimension of all `Tensor`
       objects inside should be the same (i.e. batch size).

--- a/neural_structured_learning/lib/adversarial_neighbor.py
+++ b/neural_structured_learning/lib/adversarial_neighbor.py
@@ -169,7 +169,7 @@ class _GenAdvNeighbor(abs_gen.GenNeighbor):
     the dense features will be perturbed and the values of sparse features will
     remain the same.
 
-    Arguments:
+    Args:
       input_features: a dense (float32) tensor, a list of dense tensors, or a
         dictionary of feature names and dense tensors. The shape of the
         tensor(s) should be either:
@@ -285,7 +285,7 @@ def gen_adv_neighbor(input_features,
   where `adv_step_size` is the step size (analogous to learning rate) for
   searching/calculating adversarial neighbor.
 
-  Arguments:
+  Args:
     input_features: a dense (float32) tensor, a list of dense tensors, or a
       dictionary of feature names and dense tensors. The shape of the tensor(s)
       should be either:

--- a/research/gam/gam/data/dataset.py
+++ b/research/gam/gam/data/dataset.py
@@ -208,7 +208,7 @@ class Dataset(object):
   def label_samples(self, indices_samples, new_labels):
     """Updates the labels of the samples with the provided indices.
 
-    Arguments:
+    Args:
       indices_samples: Array of integers representing the sample indices to
         update. These must samples that are not already considered training
         samples, otherwise they will be duplicated.
@@ -231,7 +231,7 @@ class Dataset(object):
   def update_labels(self, indices, new_labels):
     """Updates the labels of the samples with the provided indices.
 
-    Arguments:
+    Args:
       indices: A list of integers representing sample indices.
       new_labels: A list of integers representing the new labels of th samples
         in indices_samples.
@@ -673,7 +673,7 @@ class CotrainDataset(object):
   def label_samples(self, indices_samples, new_labels):
     """Updates the labels of the samples with the provided indices.
 
-    Arguments:
+    Args:
       indices_samples: Array of integers representing the sample indices to
         update. These must samples that are not already considered training
         samples, otherwise they will be duplicated.

--- a/research/gam/gam/data/preprocessing.py
+++ b/research/gam/gam/data/preprocessing.py
@@ -62,7 +62,7 @@ def split_train_val_unlabeled(train_inputs,
                               seed=None):
   """Splits the training data into train, validation and unlabeled samples.
 
-  Arguments:
+  Args:
       train_inputs: A numpy array containing the training inputs, where the
         first dimension represents the samples.
       train_labels: A numpy array containing the training labels, where the

--- a/research/gam/gam/models/cnn.py
+++ b/research/gam/gam/models/cnn.py
@@ -276,7 +276,7 @@ class ImageCNNAgreement(Model):
     multi-class classification, it is softmax cross entropy.
     A weight decay loss is also added to the parameters passed in reg_params.
 
-    Arguments:
+    Args:
       predictions: A tensor of predictions. For multiclass classification its
         shape is (num_samples, num_classes), where the second dimension contains
         a logit per class. For binary classification, its shape is
@@ -316,7 +316,7 @@ class ImageCNNAgreement(Model):
   def normalize_predictions(self, predictions):
     """Converts predictions to probabilities.
 
-    Arguments:
+    Args:
       predictions: A tensor of logits. For multiclass classification its shape
         is (num_samples, num_classes), where the second dimension contains a
         logit per class. For binary classification, its shape is (num_samples,),

--- a/research/gam/gam/models/gcn.py
+++ b/research/gam/gam/models/gcn.py
@@ -224,7 +224,7 @@ class GCN(Model):
     multi-class classification, it is softmax cross entropy.
     A weight decay loss is also added to the parameters passed in reg_params.
 
-    Arguments:
+    Args:
       predictions: A tensor of predictions. For multiclass classification its
         shape is (num_samples, num_classes), where the second dimension contains
         a logit per class. For binary classification, its shape is
@@ -263,7 +263,7 @@ class GCN(Model):
   def normalize_predictions(self, predictions):
     """Converts predictions to probabilities.
 
-    Arguments:
+    Args:
       predictions: A tensor of logits. For multiclass classification its shape
         is (num_samples, num_classes), where the second dimension contains a
         logit per class. For binary classification, its shape is (num_samples,),

--- a/research/gam/gam/models/mlp.py
+++ b/research/gam/gam/models/mlp.py
@@ -195,7 +195,7 @@ class MLP(Model):
     multi-class classification, it is softmax cross entropy.
     A weight decay loss is also added to the parameters passed in reg_params.
 
-    Arguments:
+    Args:
       predictions: A tensor of predictions. For multiclass classification its
         shape is (num_samples, num_classes), where the second dimension contains
         a logit per class. For binary classification, its shape is
@@ -234,7 +234,7 @@ class MLP(Model):
   def normalize_predictions(self, predictions):
     """Converts predictions to probabilities.
 
-    Arguments:
+    Args:
       predictions: A tensor of logits. For multiclass classification its shape
         is (num_samples, num_classes), where the second dimension contains a
         logit per class. For binary classification, its shape is (num_samples,),

--- a/research/gam/gam/models/models_base.py
+++ b/research/gam/gam/models/models_base.py
@@ -115,7 +115,7 @@ class Model(object):
     - project_concat: The two inputs are projected to another space, and then
                       concatenated.
 
-    Arguments:
+    Args:
       inputs: A batch of features of shape (batch_size, num_features) or
         a tuple of two such batches of features.
     Returns:
@@ -145,7 +145,7 @@ class Model(object):
   def _project(self, inputs, reuse=tf.compat.v1.AUTO_REUSE):
     """Projects the provided inputs using a multilayer perceptron.
 
-    Arguments:
+    Args:
       inputs: A batch of features whose first dimension is the batch size.
       reuse: A boolean specifying whether to reuse the same projection weights
         or create new ones.

--- a/research/gam/gam/trainer/trainer_agreement.py
+++ b/research/gam/gam/trainer/trainer_agreement.py
@@ -299,7 +299,7 @@ class TrainerAgreement(Trainer):
     training an agreement model, but also from the TrainerClassification class
     when creating the agreement loss term.
 
-    Arguments:
+    Args:
       src_features: A Tensor or Placeholder of shape (batch_size, num_features)
         containing the features of the source sample of an edge.
       tgt_features: A Tensor or Placeholder of shape (batch_size, num_features)
@@ -404,7 +404,7 @@ class TrainerAgreement(Trainer):
     with respect to the true labels. This is for monitoring only, and is not
     used when training.
 
-    Arguments:
+    Args:
       data: A CotrainDataset object.
       session: A TensorFlow session.
 
@@ -436,7 +436,7 @@ class TrainerAgreement(Trainer):
     This calculates the accuracy for both class 1 (agreement) and class 0
     (disagreement).
 
-    Arguments:
+    Args:
       session: A TensorFlow session.
       feed_dict: A train feed dictionary.
 
@@ -503,7 +503,7 @@ class TrainerAgreement(Trainer):
     For nodes, the agreement labels are 1.0 if the two nodes in a pair have the
     same label, or 0.0 otherwise.
 
-    Arguments:
+    Args:
       labeled_samples: An array of integers representing the indices of the
         labeled nodes.
       num_samples: An integer representing the desired number of validation
@@ -543,7 +543,7 @@ class TrainerAgreement(Trainer):
   def _compute_ratio_pos_neg(self, labels):
     """Compute the agreement positive to negative sample ratio.
 
-    Arguments:
+    Args:
       labels: An array containing labels for the labeled samples. Note that
         these are the labels for the classification task, not for the agreement
         prediction task, so they are in range [0, num_classes - 1].
@@ -746,7 +746,7 @@ class TrainerAgreement(Trainer):
     we keep them as inputs to this function because we want to have a common
     interface with the TrainerPerfectAgreement class.
 
-    Arguments:
+    Args:
       session: A TensorFlow session where to run the model.
       src_features: An array of shape (num_samples, num_features) containing the
         features of the first element of the pair.
@@ -779,7 +779,7 @@ class TrainerAgreement(Trainer):
     as a weighted average of the labeled samples, using the predicted agreement
     scores as weights.
 
-    Arguments:
+    Args:
       session: A TensorFlow seession.
       indices: A list of integers representing the indices of the test samples
         to label.
@@ -851,7 +851,7 @@ class TrainerAgreement(Trainer):
     Provides batches of node pairs, including their features and the agreement
     label (i.e. whether their labels agree).
 
-    Arguments:
+    Args:
       labeled_nodes:  An array of integers representing the indices of the
         labeled samples.
       data: A Dataset object used to provided the labels of the labeled samples.
@@ -897,7 +897,7 @@ class TrainerAgreement(Trainer):
     The agreement model is trained using pairs of labeled samples from the train
     set, and is evaluated on pairs of labeled samples from the validation set.
 
-    Arguments:
+    Args:
       labeled_samples:
       ratio_val: A number between (0, 1) representing the ratio of all labeled
         samples to be set aside for validation.
@@ -1043,7 +1043,7 @@ class TrainerPerfectAgreement(object):
     The function contains many unused arguments, in order to conform with the
     interface of the TrainerAgreement class.
 
-    Arguments:
+    Args:
       unused_session: A TensorFlow session where to run the model.
       unused_src_features: An array of shape (num_samples, num_features)
         containing the features of the first element of the pair.
@@ -1072,7 +1072,7 @@ class TrainerPerfectAgreement(object):
     TrainerAgreement, but here we use the oracle labels to make the agreement
     prediction.
 
-    Arguments:
+    Args:
       src_indices: A Tensor or Placeholder of shape (batch_size,) containing the
         indices of the samples that are the sources of the edges.
       tgt_indices: A Tensor or Placeholder of shape (batch_size,) containing the
@@ -1110,7 +1110,7 @@ class TrainerPerfectAgreement(object):
     as a weighted average of the labeled samples, using the predicted agreement
     scores as weights.
 
-    Arguments:
+    Args:
       indices: A list of integers representing the indices of the test samples
         to label.
       num_neighbors: An integer representing the number of labeled samples to
@@ -1175,7 +1175,7 @@ class TrainerAgreementAlwaysAgree(object):
     The function contains many unused arguments, in order to conform with the
     interface of the TrainerAgreement class.
 
-    Arguments:
+    Args:
       unused_session: A TensorFlow session where to run the model.
       unused_src_features: An array of shape (num_samples, num_features)
         containing the features of the first element of the pair.
@@ -1200,7 +1200,7 @@ class TrainerAgreementAlwaysAgree(object):
     This function is the equivalent of `create_agreement_prediction` in
     TrainerAgreement, but here we always predict 1.0.
 
-    Arguments:
+    Args:
       src_indices: A Tensor or Placeholder of shape (batch_size,) containing the
         indices of the samples that are the sources of the edges.
       unused_args: Other unused arguments, which we allow in order to create a

--- a/research/gam/gam/trainer/trainer_classification.py
+++ b/research/gam/gam/trainer/trainer_classification.py
@@ -417,7 +417,7 @@ class TrainerClassification(Trainer):
     both samples are labeled (LL), for one of them we use the prediction and for
     the other the true label -- otherwise there are no gradients to proagate.
 
-    Arguments:
+    Args:
       data: A CotrainDataset object.
       is_train: A placeholder for a boolean that specifies if this is function
         is called as part of model training or inference.
@@ -608,7 +608,7 @@ class TrainerClassification(Trainer):
     The first element of the pair is selected from the src_indices, and the
     second element is selected from tgt_indices.
 
-    Arguments:
+    Args:
       src_indices: Numpy array containing the indices available for the source
         node.
       tgt_indices: Numpy array containing the indices available for the tgt
@@ -731,7 +731,7 @@ class TrainerClassification(Trainer):
   def train(self, data, session=None, **kwargs):
     """Train the classification model on the provided dataset.
 
-    Arguments:
+    Args:
       data: A CotrainDataset object.
       session: A TensorFlow session or None.
       **kwargs: Other keyword arguments.

--- a/research/gam/gam/trainer/trainer_classification_gcn.py
+++ b/research/gam/gam/trainer/trainer_classification_gcn.py
@@ -451,7 +451,7 @@ class TrainerClassificationGCN(Trainer):
     both samples are labeled (LL), for one of them we use the prediction and for
     the other the true label -- otherwise there are no gradients to proagate.
 
-    Arguments:
+    Args:
       data: A CotrainDataset object.
       is_train: A placeholder for a boolean that specifies if this is function
         is called as part of model training or inference.
@@ -636,7 +636,7 @@ class TrainerClassificationGCN(Trainer):
     The first element of the pair is selected from the src_indices, and the
     second element is selected from tgt_indices.
 
-    Arguments:
+    Args:
       src_indices: Numpy array containing the indices available for the source
         node.
       tgt_indices: Numpy array containing the indices available for the tgt
@@ -743,7 +743,7 @@ class TrainerClassificationGCN(Trainer):
   def train(self, data, session=None, **kwargs):
     """Train the classification model on the provided dataset.
 
-    Arguments:
+    Args:
       data: A CotrainDataset object.
       session: A TensorFlow session or None.
       **kwargs: Other keyword arguments.

--- a/research/gam/gam/trainer/trainer_cotrain.py
+++ b/research/gam/gam/trainer/trainer_cotrain.py
@@ -343,7 +343,7 @@ class TrainerCotraining(Trainer):
   def _select_samples_to_label(self, data, trainer_cls, session):
     """Selects which samples to label next.
 
-    Arguments:
+    Args:
       data: A CotrainData object.
       trainer_cls: A TrainerClassification object.
       session: A TensorFlow Session.


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420