### PR TITLE
Update adversarial_keras_cnn_mnist.ipynb

### DIFF
--- a/g3doc/tutorials/adversarial_keras_cnn_mnist.ipynb
+++ b/g3doc/tutorials/adversarial_keras_cnn_mnist.ipynb
@@ -754,7 +754,7 @@
         "  y_adv = batch_pred['adv-regularized'][i]\n",
         "  plt.subplot(n_row, n_col, i+1)\n",
         "  plt.title('true: %d, base: %d, adv: %d' % (y, y_base, y_adv))\n",
-        "  plt.imshow(tf.keras.preprocessing.image.array_to_img(image), cmap='gray')\n",
+        "  plt.imshow(tf.keras.utils.array_to_img(image), cmap='gray')\n",
         "  plt.axis('off')\n",
         "\n",
         "plt.show()"


### PR DESCRIPTION
Updated 'tf.keras.preprocessing.image.array_to_img' to 'tf.keras.utils.array_to_img' in 'Examples of adversarially-perturbed images' section and ran the code successfully after changes.